### PR TITLE
Use correct npm peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "browser": "index.js",
   "style": "dist/css/angular-aside.css",
   "peerDependencies": {
-    "angular-bootstrap": ">=0.10.0"
+    "angular-ui-bootstrap": ">=0.10.0"
   },
   "keywords": [
     "angular",


### PR DESCRIPTION
`angular-ui-bootstrap` is the official angular bootstrap npm module, the current one set is out of date on npm. Thanks!