### PR TITLE
Add support for UI Bootstrap 0.14 Prefixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 angular-aside ![bower version](http://img.shields.io/bower/v/angular-aside.svg) [![npm version](https://badge.fury.io/js/angular-aside.svg)](https://www.npmjs.com/package/angular-aside)
 =============
 
-Off canvas side menu to use with ui-bootstrap. Extends ui-bootstrap's $modal provider.
+Off canvas side menu for use with ui-bootstrap 0.14+. Extends ui-bootstrap's $uibModal provider.
 
 ###[Live Demo](http://plnkr.co/edit/G7vMSv?p=preview)
 
@@ -36,7 +36,7 @@ angular.module('myApp')
   });
 ```
 
-Supports all configuration that `$modal` has. Can be used with both `template` and `templateUrl`. For more info hit **Modal** section on [angular-ui bootstrap](http://angular-ui.github.io/bootstrap) documentation.
+Supports all configuration that `$uibModal` has. Can be used with both `template` and `templateUrl`. For more info hit **Modal** section on [angular-ui bootstrap](http://angular-ui.github.io/bootstrap) documentation.
 
 
 ##Additional Config

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-aside",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "homepage": "https://github.com/dbtek/angular-aside",
   "author": {
     "name": "İsmail Demirbilek",
@@ -31,9 +31,9 @@
     "package.json"
   ],
   "dependencies": {
-    "angular-bootstrap": ">=0.10.0"
+    "angular-bootstrap": ">=0.14.0"
   },
   "devDependencies": {
-    "angular-mocks": ">=1.2.0"
+    "angular-mocks": ">=1.4.0"
   }
 }

--- a/dist/css/angular-aside.css
+++ b/dist/css/angular-aside.css
@@ -1,7 +1,7 @@
 /*!
- * angular-aside - v1.2.1
+ * angular-aside - v1.3.0
  * https://github.com/dbtek/angular-aside
- * 2015-10-06
+ * 2015-10-22
  * Copyright (c) 2015 İsmail Demirbilek
  * License: MIT
  */

--- a/dist/css/angular-aside.min.css
+++ b/dist/css/angular-aside.min.css
@@ -1,7 +1,7 @@
 /*!
- * angular-aside - v1.2.1
+ * angular-aside - v1.3.0
  * https://github.com/dbtek/angular-aside
- * 2015-10-06
+ * 2015-10-22
  * Copyright (c) 2015 İsmail Demirbilek
  * License: MIT
  */

--- a/dist/js/angular-aside.js
+++ b/dist/js/angular-aside.js
@@ -1,8 +1,8 @@
 
 /*!
- * angular-aside - v1.2.1
+ * angular-aside - v1.3.0
  * https://github.com/dbtek/angular-aside
- * 2015-10-06
+ * 2015-10-22
  * Copyright (c) 2015 İsmail Demirbilek
  * License: MIT
  */
@@ -20,15 +20,15 @@
 })();
 
 (function() {
-  angular.module('ngAside')
+angular.module('ngAside')
     /**
      * @ngdoc service
      * @name ngAside.services:$aside
      * @description
-     * Factory to create a modal instance to use it as aside. It simply wraps $modal by overriding open() method and sets a class on modal window.
+     * Factory to create a uibModal instance to use it as aside. It simply wraps $uibModal by overriding open() method and sets a class on modal window.
      * @function
      */
-    .factory('$aside', function($modal) {
+    .factory('$aside', function($uibModal) {
       var defaults = this.defaults = {
         placement: 'left'
       };
@@ -45,12 +45,12 @@
           // set aside classes
           options.windowClass  = 'ng-aside ' + vertHoriz + ' ' + options.placement + (options.windowClass ? ' ' + options.windowClass : '');
           delete options.placement
-          return $modal.open(options);
+          return $uibModal.open(options);
         }
       };
 
-      // create $aside as extended $modal
-      var $aside = angular.extend({}, $modal, asideFactory);
+      // create $aside as extended $uibModal
+      var $aside = angular.extend({}, $uibModal, asideFactory);
       return $aside;
     });
 })();

--- a/dist/js/angular-aside.min.js
+++ b/dist/js/angular-aside.min.js
@@ -1,8 +1,8 @@
 /*!
- * angular-aside - v1.2.1
+ * angular-aside - v1.3.0
  * https://github.com/dbtek/angular-aside
- * 2015-10-06
+ * 2015-10-22
  * Copyright (c) 2015 İsmail Demirbilek
  * License: MIT
  */
-!function(){angular.module("ngAside",["ui.bootstrap.modal"])}(),function(){angular.module("ngAside").factory("$aside",["$modal",function(a){var b=this.defaults={placement:"left"},c={open:function(c){var d=angular.extend({},b,c);-1===["left","right","bottom","top"].indexOf(d.placement)&&(d.placement=b.placement);var e=-1===["left","right"].indexOf(d.placement)?"vertical":"horizontal";return d.windowClass="ng-aside "+e+" "+d.placement+(d.windowClass?" "+d.windowClass:""),delete d.placement,a.open(d)}},d=angular.extend({},a,c);return d}])}();
+!function(){angular.module("ngAside",["ui.bootstrap.modal"])}(),function(){angular.module("ngAside").factory("$aside",["$uibModal",function(a){var b=this.defaults={placement:"left"},c={open:function(c){var d=angular.extend({},b,c);-1===["left","right","bottom","top"].indexOf(d.placement)&&(d.placement=b.placement);var e=-1===["left","right"].indexOf(d.placement)?"vertical":"horizontal";return d.windowClass="ng-aside "+e+" "+d.placement+(d.windowClass?" "+d.windowClass:""),delete d.placement,a.open(d)}},d=angular.extend({},a,c);return d}])}();

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "angular-aside",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "repository": "https://github.com/dbtek/angular-aside",
   "license": "MIT",
   "browser": "index.js",
   "style": "dist/css/angular-aside.css",
   "peerDependencies": {
-    "angular-ui-bootstrap": ">=0.10.0"
+    "angular-ui-bootstrap": ">=0.14.0"
   },
   "keywords": [
     "angular",

--- a/src/scripts/services/aside.js
+++ b/src/scripts/services/aside.js
@@ -1,4 +1,6 @@
 (function() {
+  'use strict';
+
   angular.module('ngAside')
     /**
      * @ngdoc service

--- a/src/scripts/services/aside.js
+++ b/src/scripts/services/aside.js
@@ -4,10 +4,10 @@
      * @ngdoc service
      * @name ngAside.services:$aside
      * @description
-     * Factory to create a modal instance to use it as aside. It simply wraps $modal by overriding open() method and sets a class on modal window.
+     * Factory to create a uibModal instance to use it as aside. It simply wraps $uibModal by overriding open() method and sets a class on modal window.
      * @function
      */
-    .factory('$aside', function($modal) {
+    .factory('$aside', function($uibModal) {
       var defaults = this.defaults = {
         placement: 'left'
       };
@@ -24,12 +24,12 @@
           // set aside classes
           options.windowClass  = 'ng-aside ' + vertHoriz + ' ' + options.placement + (options.windowClass ? ' ' + options.windowClass : '');
           delete options.placement
-          return $modal.open(options);
+          return $uibModal.open(options);
         }
       };
 
-      // create $aside as extended $modal
-      var $aside = angular.extend({}, $modal, asideFactory);
+      // create $aside as extended $uibModal
+      var $aside = angular.extend({}, $uibModal, asideFactory);
       return $aside;
     });
 })();

--- a/test/spec/services/aside.js
+++ b/test/spec/services/aside.js
@@ -10,7 +10,7 @@ describe('Service: $aside', function () {
 
   beforeEach(inject(function ($injector) {
     $aside = $injector.get('$aside');
-    $modal =  $injector.get('$modal');
+    $modal =  $injector.get('$uibModal');
   }));
 
   it('should do something', function () {


### PR DESCRIPTION
This updates the existing angular-aside code to use UI Bootstrap 0.14 with the updated $uibModal service rather than the depreciated $modal service. Would close #32.

Does this seem like it's missing anything? Did a quick test by dropping into an existing app and it seemed work and suppress the $modal depreciation errors.