### PR TITLE
Remove bower install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "time-grunt": "~0.2.7"
   },
   "scripts": {
-    "postinstall": "bower install",
     "test": "grunt test"
   },
   "engines": {


### PR DESCRIPTION
As I don't use bower the postinstall script fails which means I can't update this module. Thanks! :smile: 

```
Matts-MBP:ssi-webapp mattlewis$ npm install --save angular-aside@1.3.1

> angular-aside@1.3.1 postinstall /Users/mattlewis/Sites/ssi-webapp/node_modules/angular-aside
> bower install

bower                           ENOENT No bower.json present

npm ERR! Darwin 15.0.0
npm ERR! argv "/usr/local/Cellar/node/5.0.0/bin/node" "/usr/local/bin/npm" "install" "--save" "angular-aside@1.3.1"
npm ERR! node v5.0.0
npm ERR! npm  v3.4.0
npm ERR! code ELIFECYCLE

npm ERR! angular-aside@1.3.1 postinstall: `bower install`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the angular-aside@1.3.1 postinstall script 'bower install'.
npm ERR! Make sure you have the latest version of node.js and npm installed.
npm ERR! If you do, this is most likely a problem with the angular-aside package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     bower install
npm ERR! You can get their info via:
npm ERR!     npm owner ls angular-aside
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/mattlewis/Sites/ssi-webapp/npm-debug.log
```