### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ Off canvas side menu for use with ui-bootstrap 0.14+. Extends ui-bootstrap's `$u
 
 :information_desk_person: Please use v1.2.x for ui-bootstrap versions 0.13 and below.
 
-###[Live Demo](http://plnkr.co/edit/G7vMSv?p=preview)
+### [Live Demo](http://plnkr.co/edit/G7vMSv?p=preview)
 
-##Install
+## Install
 
 #### Bower:
 ```bash
@@ -20,7 +20,7 @@ Then, include css/js in html.
  $ npm install angular-aside
 ```
 
-##Usage
+## Usage
 
 ```js
  angular.module('myApp', ['ui.bootstrap', 'ngAside']);
@@ -41,15 +41,15 @@ angular.module('myApp')
 Supports all configuration that `$uibModal` has. Can be used with both `template` and `templateUrl`. For more info hit **Modal** section on [angular-ui bootstrap](http://angular-ui.github.io/bootstrap) documentation.
 
 
-##Additional Config
+## Additional Config
 - `placement` - Aside placement can be `'left'`, `'right'`, `'top'`, or `'bottom'`.
 
 
-##Credits
+## Credits
 - [Angular UI Bootstrap](angular-ui.github.io/bootstrap/)
 - [Animate.css](http://daneden.github.io/animate.css/)
 
 
-##Author
+## Author
 
 İsmail Demirbilek ([@dbtek](https://twitter.com/dbtek))


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
